### PR TITLE
Import Herbarium font if not present

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,14 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300..800&display=swap" rel="stylesheet">
   <style>
+    @font-face {
+      font-family: 'Herbarium';
+      src: url('fonts/Herbarium.woff2') format('woff2'),
+           url('fonts/Herbarium.woff') format('woff');
+      font-weight: 400;
+      font-style: normal;
+      font-display: swap;
+    }
     :root {
       --main-bg: #fff;
       --main-color: #2C2C2C;


### PR DESCRIPTION
Add `@font-face` rule for Herbarium font to `index.html` to import it into the project.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca4525e2-310f-4f33-9d22-852800fc3e7a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ca4525e2-310f-4f33-9d22-852800fc3e7a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

