### PR TITLE
Show background without hero dimming

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,11 +257,7 @@
       background-color: #1a1a1a;
     }
     .hero::after {
-      content: '';
-      position: absolute;
-      inset: 0;
-      z-index: 0;
-      background: linear-gradient(0deg, rgba(0,0,0,0.45), rgba(0,0,0,0.45));
+      content: none;
     }
     .hero-content {
       position: relative;


### PR DESCRIPTION
Remove dark overlay from hero section to ensure background is fully visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-1af91436-20b0-43ce-a380-dee69a9ae913">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1af91436-20b0-43ce-a380-dee69a9ae913">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

