### PR TITLE
Load herbarium font from CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,17 +13,13 @@
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Manrope:wght@300..800&display=swap"></noscript>
   <link rel="preconnect" href="https://mojazemlja.rs" crossorigin>
   <link rel="dns-prefetch" href="https://mojazemlja.rs">
-  <link rel="preload" as="font" href="fonts/Herbarium.woff2" type="font/woff2" crossorigin>
+  <link rel="preconnect" href="https://fonts.cdnfonts.com">
+  <link rel="dns-prefetch" href="https://fonts.cdnfonts.com">
+  <link rel="preload" as="style" href="https://fonts.cdnfonts.com/css/herbarium">
+  <link rel="stylesheet" href="https://fonts.cdnfonts.com/css/herbarium" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="https://fonts.cdnfonts.com/css/herbarium"></noscript>
   <link rel="preload" as="image" href="https://mojazemlja.rs/img/moja-zemlja-bg.webp" fetchpriority="high">
   <style>
-    @font-face {
-      font-family: 'Herbarium';
-      src: url('fonts/Herbarium.woff2') format('woff2'),
-           url('fonts/Herbarium.woff') format('woff');
-      font-weight: 400;
-      font-style: normal;
-      font-display: swap;
-    }
     :root {
       --main-bg: #fff;
       --main-color: #2C2C2C;


### PR DESCRIPTION
Load Herbarium font from CDN because the local file was missing.

---
<a href="https://cursor.com/background-agent?bcId=bc-a02a5495-fa73-46c9-9382-cfdc4f4e6d20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a02a5495-fa73-46c9-9382-cfdc4f4e6d20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

