### PR TITLE
Fix logo stretching by removing width

### DIFF
--- a/index.html
+++ b/index.html
@@ -492,8 +492,8 @@
 </head>
 <body>
   <header>
-    <div class="logo">
-             <img src="https://mojazemlja.rs/img/moja-zemlja-logo.png" alt="Moja Zemlja" width="198" height="66" decoding="async" />
+         <div class="logo">
+             <img src="https://mojazemlja.rs/img/moja-zemlja-logo.png" alt="Moja Zemlja" height="66" decoding="async" />
     </div>
     <nav>
       <ul class="nav-list">
@@ -646,7 +646,7 @@
   </section>
 
   <footer>
-         <img class="footer-logo" src="https://mojazemlja.rs/img/moja-zemlja-logo.png" alt="Moja Zemlja" loading="lazy" decoding="async" fetchpriority="low" width="198" height="56" />
+         <img class="footer-logo" src="https://mojazemlja.rs/img/moja-zemlja-logo.png" alt="Moja Zemlja" loading="lazy" decoding="async" fetchpriority="low" height="56" />
     <div class="footer-text">2025 Moja Zemlja. Sva prava zadržana.</div>
   </footer>
 


### PR DESCRIPTION
Remove `width` attributes from header and footer logo images to prevent stretching and maintain aspect ratio.

---
<a href="https://cursor.com/background-agent?bcId=bc-48fbafe2-8cec-4bcd-bf21-ce4b675321db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-48fbafe2-8cec-4bcd-bf21-ce4b675321db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

