### PR TITLE
Set mobile heading line height to one

### DIFF
--- a/index.html
+++ b/index.html
@@ -474,6 +474,7 @@
       .mobile-nav {
         top: var(--header-height-mobile);
       }
+      h1, h2, h3, h4, h5, h6 { line-height: 1; }
     }
     @media (max-width: 600px) {
       .hero h1 { font-size: 2em; }


### PR DESCRIPTION
Apply line-height: 1 to all headings on mobile devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2df624c-ae2b-42ca-a772-fb51ade32f92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d2df624c-ae2b-42ca-a772-fb51ade32f92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

