### PR TITLE
Manage font files in /fonts/

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,11 +13,32 @@
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Manrope:wght@300..800&display=swap"></noscript>
   <link rel="preconnect" href="https://mojazemlja.rs" crossorigin>
   <link rel="dns-prefetch" href="https://mojazemlja.rs">
-  <link rel="preconnect" href="https://fonts.cdnfonts.com">
-  <link rel="dns-prefetch" href="https://fonts.cdnfonts.com">
-  <link rel="stylesheet" href="https://fonts.cdnfonts.com/css/herbarium">
+  <link rel="preload" href="/fonts/Herbarium.otf" as="font" type="font/otf" crossorigin>
+  <link rel="preload" href="/fonts/Herbarium-Regular-Alt.otf" as="font" type="font/otf" crossorigin>
+  <link rel="preload" href="/fonts/Herbarium-Extras.otf" as="font" type="font/otf" crossorigin>
   <link rel="preload" as="image" href="https://mojazemlja.rs/img/moja-zemlja-bg.webp" fetchpriority="high">
   <style>
+    @font-face {
+      font-family: 'Herbarium';
+      src: url('/fonts/Herbarium.otf') format('opentype');
+      font-weight: 400;
+      font-style: normal;
+      font-display: swap;
+    }
+    @font-face {
+      font-family: 'Herbarium Alt';
+      src: url('/fonts/Herbarium-Regular-Alt.otf') format('opentype');
+      font-weight: 400;
+      font-style: normal;
+      font-display: swap;
+    }
+    @font-face {
+      font-family: 'Herbarium Extras';
+      src: url('/fonts/Herbarium-Extras.otf') format('opentype');
+      font-weight: 400;
+      font-style: normal;
+      font-display: swap;
+    }
     :root {
       --main-bg: #fff;
       --main-color: #2C2C2C;


### PR DESCRIPTION
Migrate Herbarium fonts to self-hosted local files for improved performance and reliability.

---
<a href="https://cursor.com/background-agent?bcId=bc-c69b31a6-d5b9-4fd6-8806-e28750f37119">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c69b31a6-d5b9-4fd6-8806-e28750f37119">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

