### PR TITLE
Popravi zemlja koja zaradjuje h1 oznaku

### DIFF
--- a/index.html
+++ b/index.html
@@ -583,7 +583,7 @@
 
   <section class="hero" id="home">
     <div class="hero-content">
-      <h1>Zemlja koja zaradjuje</h1>
+      <h2>Zemlja koja zaradjuje</h2>
       <p>Moja Zemlja je platforma koja nudi investiranje u poljoprivredu potpuno jednostavno i pasivno.</p>
       <p>Bilo da se interesuješ za ulaganje u novu plantažu ili želiš da kupiš stabla od drugih investitora - na pravom si mestu!</p>
       <a class="btn-main" href="#market">Kupi od drugih investitora</a>


### PR DESCRIPTION
Change 'Zemlja koja zaradjuje' from `h1` to `h2` for semantic correctness.

---
<a href="https://cursor.com/background-agent?bcId=bc-a50c2304-eb41-465e-a52b-90956dcc29ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a50c2304-eb41-465e-a52b-90956dcc29ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

