### PR TITLE
Popravi zemlja koja zaradjuje h1 oznaku

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,7 +297,7 @@
       margin: 0 auto;
       padding: 1em;
     }
-    .hero h1 {
+    .hero h2 {
       font-size: 80px;
       margin-bottom: 0.3em;
       font-family: 'Herbarium', Arial, Helvetica, sans-serif;
@@ -535,7 +535,7 @@
       }
     }
     @media (max-width: 600px) {
-      .hero h1 { font-size: 2em; }
+      .hero h2 { font-size: 2em; }
       .features { gap: 1em; }
       .section { padding: 1em; }
       .articles { gap: 0.7em; }
@@ -583,7 +583,7 @@
 
   <section class="hero" id="home">
     <div class="hero-content">
-      <h1>Zemlja koja zaradjuje</h1>
+      <h2>Zemlja koja zaradjuje</h2>
       <p>Moja Zemlja je platforma koja nudi investiranje u poljoprivredu potpuno jednostavno i pasivno.</p>
       <p>Bilo da se interesuješ za ulaganje u novu plantažu ili želiš da kupiš stabla od drugih investitora - na pravom si mestu!</p>
       <a class="btn-main" href="#market">Kupi od drugih investitora</a>


### PR DESCRIPTION
Downgrade 'Zemlja koja zaradjuje' heading from h1 to h2 and update associated CSS selectors.

---
<a href="https://cursor.com/background-agent?bcId=bc-711835ef-b31f-4637-83bd-3762169a0010">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-711835ef-b31f-4637-83bd-3762169a0010">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

