### PR TITLE
Make header transparent over hero image

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,9 @@
       font-weight: 400;
       line-height: 1.75;
     }
+    /* Offset in-page anchors for fixed header */
+    html { scroll-padding-top: var(--header-height); }
+    @media (max-width: 700px) { html { scroll-padding-top: var(--header-height-mobile); } }
     header {
       background: transparent;
       color: #fff;
@@ -70,8 +73,7 @@
       align-items: center;
       justify-content: space-between;
       padding: 0 0.5em;
-      position: -webkit-sticky;
-      position: sticky;
+      position: fixed;
       top: 0;
       left: 0;
       right: 0;
@@ -298,11 +300,15 @@
     .hero-content {
       position: relative;
       z-index: 1;
+      padding-top: var(--header-height);
       text-align: left;
       max-width: 1024px;
       width: 100%;
       margin: 0 auto;
       padding: 1em;
+    }
+    @media (max-width: 700px) {
+      .hero-content { padding-top: var(--header-height-mobile); }
     }
     .hero h2 {
       font-size: 80px;


### PR DESCRIPTION
Make transparent header overlay hero section by changing its position to fixed and adjusting content padding.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e211c5d-ff50-406a-ba54-58286c03664d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9e211c5d-ff50-406a-ba54-58286c03664d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

