### PR TITLE
Use specific mobile logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -593,6 +593,7 @@
   <header>
          <div class="logo">
              <picture>
+               <source media="(max-width: 700px)" srcset="https://mojazemlja.rs/img/logo-black.png">
                
                <img id="site-logo" src="https://mojazemlja.rs/img/moja-zemlja-logo.png" alt="Moja Zemlja" height="66" decoding="async" />
              </picture>
@@ -871,7 +872,7 @@
 
       const isMobile = window.innerWidth <= 700;
       if (logoImg) {
-        if (isMobile && isScrolled) {
+        if (isMobile) {
           logoImg.src = 'https://mojazemlja.rs/img/logo-black.png';
         } else {
           logoImg.src = 'https://mojazemlja.rs/img/moja-zemlja-logo.png';


### PR DESCRIPTION
Use the black logo on mobile devices for better visibility on a white background.

The original logo was not suitable for a white background on mobile. This change ensures the black logo is used consistently on mobile by adding a `<source>` tag for immediate loading and updating the JavaScript logic to always apply the black logo on mobile, irrespective of scroll state.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c2827c2-43a6-47c5-bb05-b88568557c07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5c2827c2-43a6-47c5-bb05-b88568557c07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

