### PR TITLE
Fix hero text horizontal scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,7 @@
       scroll-behavior: smooth;
       font-weight: 400;
       line-height: 1.75;
+      overflow-x: hidden;
     }
     /* Offset in-page anchors for fixed header */
     html { scroll-padding-top: var(--header-height); }
@@ -306,6 +307,7 @@
       width: 100%;
       margin: 0 auto;
       padding: 1em;
+      box-sizing: border-box;
     }
     @media (max-width: 700px) {
       .hero-content { padding-top: var(--header-height-mobile); }


### PR DESCRIPTION
Fixes horizontal scroll caused by hero text overflow on small screens by adding `box-sizing: border-box` to `.hero-content` and `overflow-x: hidden` to `html, body`.

---
<a href="https://cursor.com/background-agent?bcId=bc-913480d1-4141-4de8-9122-c40ca345adf3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-913480d1-4141-4de8-9122-c40ca345adf3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

