### PR TITLE
Submit form and remove alert

### DIFF
--- a/index.php
+++ b/index.php
@@ -878,14 +878,7 @@ unset($_SESSION['success'], $_SESSION['error']);
     document.addEventListener('DOMContentLoaded', updateHeaderStyle);
     updateHeaderStyle();
 
-    // Attach simple success behavior to all simple forms
-    document.querySelectorAll('form.simple-form').forEach(function(formEl){
-      formEl.addEventListener('submit', function(e){
-        e.preventDefault();
-        alert('Hvala! Uspesno ste poslali podatke. Javićemo se uskoro.');
-        formEl.reset();
-      });
-    });
+
   </script>
 </body>
 </html>


### PR DESCRIPTION
Removed JavaScript submit handler to allow form submission to `prijava.php` and remove the alert.

The previous handler prevented the form from submitting and instead displayed an alert message.

---
<a href="https://cursor.com/background-agent?bcId=bc-fc1e9181-02df-4c80-9a74-cbbd932403ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fc1e9181-02df-4c80-9a74-cbbd932403ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

