### PR TITLE
Preload hero image for faster page

### DIFF
--- a/index.php
+++ b/index.php
@@ -16,7 +16,7 @@ unset($_SESSION['success'], $_SESSION['error']);
   <link rel="preconnect" href="https://mojazemlja.rs" crossorigin>
   <link rel="dns-prefetch" href="https://mojazemlja.rs">
   <link rel="preload" href="/fonts/Herbarium.otf" as="font" type="font/otf" crossorigin>
-  <link rel="preload" as="image" href="https://mojazemlja.rs/img/moja-zemlja-bg.webp" fetchpriority="high">
+  <link rel="preload" as="image" href="https://mojazemlja.rs/img/moja-zemlja-bg.webp" type="image/webp" fetchpriority="high">
   <style>
     @font-face {
       font-family: 'Herbarium';


### PR DESCRIPTION
Add `type="image/webp"` to the hero image preload link to improve page load performance.

---
<a href="https://cursor.com/background-agent?bcId=bc-527d9af3-2997-44d1-a2ca-3c36d95c4051">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-527d9af3-2997-44d1-a2ca-3c36d95c4051">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

