### PR TITLE
Remove cropped-logo-32x32.png file

### DIFF
--- a/index.php
+++ b/index.php
@@ -25,7 +25,6 @@ header('Vary: Accept-Encoding');
   <title>Moja Zemlja - Investiranje u poljoprivredu</title>
   <meta name="description" content="Platforma za investiranje u poljoprivredu: orahe, borovnice, maline, lešnike... Ulaganje u 1 hektar ili u jedno stablo.">
   <meta name='robots' content='index, follow' />
-  <link rel="icon" href="https://mojazemlja.rs/wp-content/uploads/2023/12/cropped-logo-32x32.png" sizes="32x32">
   <link rel="preconnect" href="https://mojazemlja.rs" crossorigin>
   <link rel="dns-prefetch" href="https://mojazemlja.rs">
   <meta property="og:title" content="Moja Zemlja - Investiranje u poljoprivredu. Jednostavno. Pasivno." />


### PR DESCRIPTION
Remove `cropped-logo-32x32.png` favicon link from `index.php`.

---
<a href="https://cursor.com/background-agent?bcId=bc-a1bb8e44-eaad-4ce0-a7e1-7959e975d2d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a1bb8e44-eaad-4ce0-a7e1-7959e975d2d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

