### PR TITLE
Remove preload link for background image

### DIFF
--- a/index.php
+++ b/index.php
@@ -42,7 +42,6 @@ header('Vary: Accept-Encoding');
   <style>img:is([sizes="auto" i], [sizes^="auto," i]) { contain-intrinsic-size: 3000px 1500px }</style>
   <link rel="preload" href="/fonts/Herbarium.otf" as="font" type="font/otf" crossorigin>
   <link rel="preload" as="image" href="/img/moja-zemlja-bg-mobile.webp" type="image/webp" fetchpriority="high" media="(max-width: 768px)">
-  <link rel="preload" as="image" href="/img/moja-zemlja-bg.webp" type="image/webp" media="(min-width: 769px)">
   <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
   <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
   <style>


### PR DESCRIPTION
Remove the desktop image preload link for `moja-zemlja-bg.webp` from `index.php` as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-ebfc1355-d669-438b-8be3-6621503d4b81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ebfc1355-d669-438b-8be3-6621503d4b81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

