### PR TITLE
Check color contrast for readability

### DIFF
--- a/index.php
+++ b/index.php
@@ -347,7 +347,7 @@ header('Vary: Accept-Encoding');
     }
     .btn-main {
       background: var(--accent);
-      color: #222;
+      color: #000;
       border: var(--btn-border);
       padding: 0.8em 2em;
       font-size: 1.1em;
@@ -370,6 +370,15 @@ header('Vary: Accept-Encoding');
       color: #222;
       border: 2px solid var(--accent);
       /* transform removed to prevent size change */
+    }
+    .btn-main.is-disabled,
+    .btn-main[aria-disabled="true"] {
+      pointer-events: none;
+      background: #E8E2A5;
+      color: #000;
+      border: 2px solid #E8E2A5;
+      opacity: 1;
+      cursor: not-allowed;
     }
     /* Simple form alignment */
     .simple-form input[type="email"] {
@@ -410,7 +419,7 @@ header('Vary: Accept-Encoding');
     }
     #aktivna-ponuda h2,
     #market h2 {
-      color: var(--accent);
+      color: var(--main-color);
       font-family: 'Herbarium', Arial, Helvetica, sans-serif;
     }
     .features {
@@ -507,7 +516,7 @@ header('Vary: Accept-Encoding');
     .feature div:not(.feature-title) {
       font-size: 20px;
       box-sizing: border-box;
-      color: rgb(118, 118, 118);
+      color: #222;
       font-family: Manrope, Arial, Helvetica, sans-serif;
       font-style: normal;
       font-weight: 400;
@@ -790,7 +799,7 @@ header('Vary: Accept-Encoding');
             <div>- % godišnji povrat</div>
             <div>- € po stablu</div>
           </div>
-          <span class="btn-main" style="pointer-events:none;opacity:0.7">USKORO</span>
+          <span class="btn-main is-disabled" aria-disabled="true">USKORO</span>
         </div>
       </div>
 
@@ -805,7 +814,7 @@ header('Vary: Accept-Encoding');
             <div>- % godišnji povrat</div>
             <div>- € po stablu</div>
           </div>
-          <span class="btn-main" style="pointer-events:none;opacity:0.7">USKORO</span>
+          <span class="btn-main is-disabled" aria-disabled="true">USKORO</span>
         </div>
       </div>
 
@@ -820,7 +829,7 @@ header('Vary: Accept-Encoding');
             <div>+7,63% godišnji povrat</div>
             <div>298€ po stablu</div>
           </div>
-          <span class="btn-main" style="pointer-events:none;opacity:0.7">Prodato</span>
+          <span class="btn-main is-disabled" aria-disabled="true">Prodato</span>
         </div>
       </div>
 
@@ -835,7 +844,7 @@ header('Vary: Accept-Encoding');
             <div>+7,2% godišnji povrat</div>
             <div>200€ po stablu</div>
           </div>
-          <span class="btn-main" style="pointer-events:none;opacity:0.7">Prodato</span>
+          <span class="btn-main is-disabled" aria-disabled="true">Prodato</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Improve color contrast for headings, body text, and disabled buttons to meet WCAG accessibility standards.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7258a50-fe39-4dba-a8b7-0e8972e95084">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a7258a50-fe39-4dba-a8b7-0e8972e95084">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

